### PR TITLE
chore: Link to projects that opens in new windows

### DIFF
--- a/blog/2022-05-14-a-page-with-tools.md
+++ b/blog/2022-05-14-a-page-with-tools.md
@@ -16,24 +16,25 @@ And we're starting with the tools that we've built ourselves to start with.
 
 These are some of the tools we've built ourselves.
 
-## CF-MC-Server
+## <a href="https://cf-community.com/cf-mc-server" target="_blank">CF-MC-Server</a>
 
 This one packs a punch. It's a CLI (Command Line Interface) that allows you to install a Minecraft server, with the extra feature, that you can download modpacks from CurseForge with it, and use as servers.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>
 
-## What CurseForge project is this? / CFLookup
+## <a href="https://cflookup.com" target="_blank">What CurseForge project is this? / CFLookup</a>
 
 This project aims to provide a way to look up CurseForge projects by their ID, and get the project's data, which is used to get the project's page.
 
 And we also get really cool embeds, that you can use in your Discord server, Twitter, Facebook, LinkedIn, etc.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>
 
-## CurseForge API Client (.NET, NuGet)
+## <a href="https://www.nuget.org/packages/CurseForge.APIClient/" target="_blank">CurseForge API Client (.NET, NuGet)</a>
 
 This project aims to be a fully functional .NET client that allows you to use the CurseForge API,
 
 All you need is an API key, your partner ID and a contact email to get started.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>
+

--- a/src/pages/tools.md
+++ b/src/pages/tools.md
@@ -5,24 +5,24 @@ description: Tools made by the CurseForge Community
 
 # Community Tools
 
-## CF-MC-Server
+## <a href="https://cf-community.com/cf-mc-server" target="_blank">CF-MC-Server</a>
 
 This one packs a punch. It's a CLI (Command Line Interface) that allows you to install a Minecraft server, with the extra feature, that you can download modpacks from CurseForge with it, and use as servers.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>
 
-## What CurseForge project is this? / CFLookup
+## <a href="https://cflookup.com" target="_blank">What CurseForge project is this? / CFLookup</a>
 
 This project aims to provide a way to look up CurseForge projects by their ID, and get the project's data, which is used to get the project's page.
 
 And we also get really cool embeds, that you can use in your Discord server, Twitter, Facebook, LinkedIn, etc.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>
 
-## CurseForge API Client (.NET, NuGet)
+## <a href="https://www.nuget.org/packages/CurseForge.APIClient/" target="_blank">CurseForge API Client (.NET, NuGet)</a>
 
 This project aims to be a fully functional .NET client that allows you to use the CurseForge API,
 
 All you need is an API key, your partner ID and a contact email to get started.
 
-Made by: [NoLifeKing85](https://nolifeking85.tv)
+Made by: <a href="https://nolifeking85.tv" target="_blank">NoLifeKing85</a>


### PR DESCRIPTION
Added links to projects, they open in new windows, instead of replacing the current site.